### PR TITLE
Ensure SPA assets included in server build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run build:client && npm run build:server",
+    "build": "npm run build:client && npm run build:server && npm run build:bundle",
     "build:client": "vite build",
     "build:server": "vite build --config vite.config.server.ts",
+    "build:bundle": "node scripts/copy-spa-to-server.mjs",
     "start": "node dist/server/production.mjs",
     "test": "vitest --run",
     "format.fix": "prettier --write .",

--- a/scripts/copy-spa-to-server.mjs
+++ b/scripts/copy-spa-to-server.mjs
@@ -1,0 +1,29 @@
+import fs from "fs";
+import path from "path";
+
+const rootDir = process.cwd();
+const spaDir = path.resolve(rootDir, "dist", "spa");
+const serverDir = path.resolve(rootDir, "dist", "server");
+const targetSpaDir = path.join(serverDir, "spa");
+
+if (!fs.existsSync(spaDir)) {
+  console.error(
+    "❌ No se encontró el directorio de la SPA compilada en dist/spa. Ejecuta 'npm run build:client' antes de copiar los archivos.",
+  );
+  process.exit(1);
+}
+
+if (!fs.existsSync(serverDir)) {
+  console.error(
+    "❌ No se encontró el directorio del servidor compilado en dist/server. Ejecuta 'npm run build:server' antes de copiar los archivos.",
+  );
+  process.exit(1);
+}
+
+if (fs.existsSync(targetSpaDir)) {
+  fs.rmSync(targetSpaDir, { recursive: true, force: true });
+}
+
+fs.cpSync(spaDir, targetSpaDir, { recursive: true });
+
+console.log("✅ Archivos de la SPA copiados dentro de dist/server/spa");

--- a/server/node-build.ts
+++ b/server/node-build.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import { createServer } from "./index";
 import * as express from "express";
@@ -7,15 +8,32 @@ const port = process.env.PORT || 3000;
 
 // In production, serve the built SPA files
 const __dirname = import.meta.dirname;
-const distPath = path.join(__dirname, "../spa");
+const staticCandidates = [
+  path.join(__dirname, "../spa"),
+  path.join(__dirname, "spa"),
+];
+
+const distPath = staticCandidates.find((candidate) => fs.existsSync(candidate)) ?? staticCandidates[0];
+
+if (!fs.existsSync(distPath)) {
+  console.warn(
+    "⚠️ No se encontraron los archivos estáticos de la SPA. Asegúrate de ejecutar 'npm run build' antes de iniciar el servidor.",
+  );
+}
 
 // Serve static files
-app.use(express.static(distPath));
+if (fs.existsSync(distPath)) {
+  app.use(express.static(distPath));
 
-// Handle React Router - serve index.html for all non-API routes
-app.get(/^\/(?!api\/|health).*/, (_req, res) => {
-  res.sendFile(path.join(distPath, "index.html"));
-});
+  // Handle React Router - serve index.html for all non-API routes
+  app.get(/^\/(?!api\/|health).*/, (_req, res) => {
+    res.sendFile(path.join(distPath, "index.html"));
+  });
+} else {
+  console.warn(
+    "⚠️ Los archivos estáticos no están disponibles; las rutas del cliente devolverán 404 hasta que se genere la compilación.",
+  );
+}
 
 app.listen(port, () => {
   console.log(`🚀 Fusion Starter server running on port ${port}`);


### PR DESCRIPTION
## Summary
- add a post-build script that copies the compiled SPA into the server output so deployments include static assets
- make the Node server look for the SPA bundle in both dist/spa and the embedded copy to avoid 404s when only the server folder is deployed

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5c152ce688330ba2e27ceb8e0944f