### PR TITLE
Handle missing Vite env in cookie script

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,15 @@
         },
       };
 
-      const mode = import.meta.env.MODE === "production" ? "production" : "test";
+      const env = (() => {
+        try {
+          return import.meta.env ?? {};
+        } catch (_error) {
+          return {};
+        }
+      })();
+
+      const mode = env.MODE === "production" ? "production" : "test";
       const config = oneTrustConfigs[mode];
 
       function appendScript(options) {


### PR DESCRIPTION
## Summary
- guard the OneTrust loader against missing Vite env metadata so it falls back gracefully

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c389309883309a33325374c8ad90