### PR TITLE
Ensure Azure static builds expose SPA entry point

### DIFF
--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -1,0 +1,12 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/favicon.ico", "/api/*"]
+  },
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/index.html",
+      "statusCode": 200
+    }
+  }
+}

--- a/scripts/copy-spa-to-server.mjs
+++ b/scripts/copy-spa-to-server.mjs
@@ -3,7 +3,8 @@ import path from "path";
 
 const rootDir = process.cwd();
 const spaDir = path.resolve(rootDir, "dist", "spa");
-const serverDir = path.resolve(rootDir, "dist", "server");
+const distDir = path.resolve(rootDir, "dist");
+const serverDir = path.join(distDir, "server");
 const targetSpaDir = path.join(serverDir, "spa");
 
 if (!fs.existsSync(spaDir)) {
@@ -26,4 +27,19 @@ if (fs.existsSync(targetSpaDir)) {
 
 fs.cpSync(spaDir, targetSpaDir, { recursive: true });
 
+// Además de copiar los archivos para el bundle del servidor, duplicamos la SPA
+// en la raíz de dist/ para que plataformas de hosting estático (como Azure
+// Static Web Apps) encuentren un index.html en el directorio esperado.
+for (const entry of fs.readdirSync(spaDir)) {
+  const sourcePath = path.join(spaDir, entry);
+  const targetPath = path.join(distDir, entry);
+
+  if (fs.existsSync(targetPath)) {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+  }
+
+  fs.cpSync(sourcePath, targetPath, { recursive: true });
+}
+
 console.log("✅ Archivos de la SPA copiados dentro de dist/server/spa");
+console.log("✅ Archivos de la SPA preparados en dist/ para despliegues estáticos");


### PR DESCRIPTION
## Summary
- duplicate the built SPA files at the dist root so static hosts serve index.html correctly
- add an Azure Static Web Apps navigation fallback configuration for client-side routing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c419f1288330b91625ac20a34134