### PR TITLE
Fix OneTrust script configuration fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,19 @@
         }
       })();
 
-      const mode = env.MODE === "production" ? "production" : "test";
-      const config = oneTrustConfigs[mode];
+      const onetrustEnv = (() => {
+        const value = env.VITE_ONETRUST_ENV;
+        if (typeof value === "string" && value.trim().toLowerCase() === "test") {
+          return "test";
+        }
+
+        return "production";
+      })();
+
+      const config = oneTrustConfigs[onetrustEnv] ?? oneTrustConfigs.production;
       const baseAutoBlockUrl = "https://cdn.cookielaw.org/consent/";
-      const autoBlockSrc = `${baseAutoBlockUrl}${config.domainScript}/OtAutoBlock.js`;
+      const domainScript = config.domainScript ?? oneTrustConfigs.production.domainScript;
+      const autoBlockSrc = `${baseAutoBlockUrl}${domainScript}/OtAutoBlock.js`;
       const stubSrc = "https://cdn.cookielaw.org/scripttemplates/otSDKStub.js";
 
       function appendScript(options) {
@@ -49,7 +58,7 @@
         src: stubSrc,
         attributes: {
           charset: "UTF-8",
-          "data-domain-script": config.domainScript,
+          "data-domain-script": domainScript,
         },
       });
 


### PR DESCRIPTION
## Summary
- default the OneTrust cookie consent loader to the production configuration unless an explicit test flag is provided
- ensure the script URLs and data attributes fall back to the production domain script when no override is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6c663b3dc8330bfcb35e495d475f1