### PR TITLE
Update Azure pipeline packaging for App Service deployment

### DIFF
--- a/infra/azure-pipelines.yml
+++ b/infra/azure-pipelines.yml
@@ -50,17 +50,49 @@ stages:
               checkLatest: true
             displayName: "Install Node.js"
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "Install dependencies"
 
           - script: npm run build
-            displayName: "npm build"
+            displayName: "Build application"
+
+          - script: npm prune --omit=dev
+            displayName: "Prune dev dependencies"
+
+          - task: DeleteFiles@1
+            displayName: "Clean staging directory"
+            condition: and(succeeded(), exists('$(Build.ArtifactStagingDirectory)/website'))
+            inputs:
+              SourceFolder: "$(Build.ArtifactStagingDirectory)/website"
+
+          - task: CopyFiles@2
+            displayName: "Copy dist to staging"
+            inputs:
+              SourceFolder: "$(Build.SourcesDirectory)/dist"
+              Contents: "**/*"
+              TargetFolder: "$(Build.ArtifactStagingDirectory)/website/dist"
+
+          - task: CopyFiles@2
+            displayName: "Copy node_modules to staging"
+            inputs:
+              SourceFolder: "$(Build.SourcesDirectory)/node_modules"
+              Contents: "**/*"
+              TargetFolder: "$(Build.ArtifactStagingDirectory)/website/node_modules"
+
+          - task: CopyFiles@2
+            displayName: "Copy package manifests"
+            inputs:
+              SourceFolder: "$(Build.SourcesDirectory)"
+              Contents: |
+                package.json
+                package-lock.json
+              TargetFolder: "$(Build.ArtifactStagingDirectory)/website"
 
           - task: ArchiveFiles@2
             displayName: "Zip package"
             condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             inputs:
-              rootFolderOrFile: "$(Build.SourcesDirectory)"
+              rootFolderOrFile: "$(Build.ArtifactStagingDirectory)/website"
               includeRootFolder: false
               archiveType: "zip"
               archiveFile: "$(Build.ArtifactStagingDirectory)/website/package.zip"


### PR DESCRIPTION
## Summary
- install dependencies with `npm ci` and run the build before pruning development-only packages
- stage only the production build output, manifests, and runtime dependencies for the App Service artifact zip

## Testing
- not run (pipeline configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6d452639c8330be15183316cfe3c6