### PR TITLE
Fix staging cleanup condition in Azure pipeline

### DIFF
--- a/infra/azure-pipelines.yml
+++ b/infra/azure-pipelines.yml
@@ -59,11 +59,13 @@ stages:
           - script: npm prune --omit=dev
             displayName: "Prune dev dependencies"
 
-          - task: DeleteFiles@1
+          - pwsh: |
+              $path = "$(Build.ArtifactStagingDirectory)/website"
+              if (Test-Path $path) {
+                Remove-Item -Path $path -Recurse -Force
+              }
             displayName: "Clean staging directory"
-            condition: and(succeeded(), exists('$(Build.ArtifactStagingDirectory)/website'))
-            inputs:
-              SourceFolder: "$(Build.ArtifactStagingDirectory)/website"
+            condition: succeeded()
 
           - task: CopyFiles@2
             displayName: "Copy dist to staging"


### PR DESCRIPTION
## Summary
- replace the DeleteFiles task condition with a PowerShell cleanup script to remove the staging folder when it exists
- avoid the unsupported `exists()` runtime expression that was causing the pipeline to fail during initialization

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68d6e23c2c1c8330bd464e8097720410