### PR TITLE
Add Azure App Service entrypoint and configuration

### DIFF
--- a/azure-server.js
+++ b/azure-server.js
@@ -1,0 +1,29 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const candidates = [
+  path.join(__dirname, "dist", "server", "production.mjs"),
+  path.join(__dirname, "dist", "server", "production.js"),
+];
+
+const entryPath = candidates.find((candidate) => existsSync(candidate));
+
+if (!entryPath) {
+  console.error(
+    "No se encontró el bundle de producción del servidor. Asegúrate de ejecutar 'npm run build' antes de iniciar la aplicación.",
+  );
+  process.exit(1);
+}
+
+const entryUrl = pathToFileURL(entryPath).href;
+
+try {
+  await import(entryUrl);
+} catch (error) {
+  console.error("Fallo al iniciar el servidor de producción", error);
+  process.exit(1);
+}

--- a/infra/azure-pipelines.yml
+++ b/infra/azure-pipelines.yml
@@ -88,6 +88,8 @@ stages:
               Contents: |
                 package.json
                 package-lock.json
+                azure-server.js
+                web.config
               TargetFolder: "$(Build.ArtifactStagingDirectory)/website"
 
           - task: ArchiveFiles@2

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:client": "vite build",
     "build:server": "vite build --config vite.config.server.ts",
     "build:bundle": "node scripts/copy-spa-to-server.mjs",
-    "start": "node dist/server/production.mjs",
+    "start": "node azure-server.js",
     "test": "vitest --run",
     "format.fix": "prettier --write .",
     "typecheck": "tsc",

--- a/web.config
+++ b/web.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="iisnode" path="azure-server.js" verb="*" modules="iisnode" />
+    </handlers>
+    <rewrite>
+      <rules>
+        <rule name="StaticFiles" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAny">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" />
+            <add input="{REQUEST_FILENAME}" matchType="IsDirectory" />
+          </conditions>
+          <action type="None" />
+        </rule>
+        <rule name="NodeRoutes" stopProcessing="true">
+          <match url=".*" />
+          <action type="Rewrite" url="azure-server.js" />
+        </rule>
+      </rules>
+    </rewrite>
+    <defaultDocument>
+      <files>
+        <clear />
+        <add value="dist/spa/index.html" />
+      </files>
+    </defaultDocument>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
## Summary
- add an Azure-specific bootstrap script so the App Service can launch the built Express server
- include an IIS web.config that routes requests through the Node server while keeping static files available
- update the Azure pipeline artifact to ship the new entrypoint and configuration and point `npm start` to the shared bootstrap

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6ebf57c808330840f8003ec1c45f0