### PR TITLE
Fix server static directory resolution for production build

### DIFF
--- a/server/node-build.ts
+++ b/server/node-build.ts
@@ -2,15 +2,17 @@ import fs from "fs";
 import path from "path";
 import { createServer } from "./index";
 import * as express from "express";
+import { fileURLToPath } from "node:url";
 
 const app = createServer();
 const port = process.env.PORT || 3000;
 
 // In production, serve the built SPA files
-const __dirname = import.meta.dirname;
+const moduleDirname = path.dirname(fileURLToPath(import.meta.url));
 const staticCandidates = [
-  path.join(__dirname, "../spa"),
-  path.join(__dirname, "spa"),
+  path.join(moduleDirname, "../spa"),
+  path.join(moduleDirname, "spa"),
+  path.join(process.cwd(), "dist", "spa"),
 ];
 
 const distPath = staticCandidates.find((candidate) => fs.existsSync(candidate)) ?? staticCandidates[0];


### PR DESCRIPTION
## Summary
- ensure the production server resolves its static SPA directory using fileURLToPath for Node compatibility
- include the project root dist/spa directory as a fallback candidate so assets are located correctly at runtime

## Testing
- pnpm build:server

------
https://chatgpt.com/codex/tasks/task_e_68d74efb5d488330ab32d2c7ce9dd839