### PR TITLE
Add IIS rewrite rules for SPA asset files

### DIFF
--- a/web.config
+++ b/web.config
@@ -14,6 +14,14 @@
           </conditions>
           <action type="None" />
         </rule>
+        <rule name="SpaAssets" stopProcessing="true">
+          <match url="^assets/(.*)$" />
+          <action type="Rewrite" url="dist/spa/assets/{R:1}" />
+        </rule>
+        <rule name="SpaFavicon" stopProcessing="true">
+          <match url="^favicon\.ico$" />
+          <action type="Rewrite" url="dist/spa/favicon.ico" />
+        </rule>
         <rule name="NodeRoutes" stopProcessing="true">
           <match url=".*" />
           <action type="Rewrite" url="azure-server.js" />


### PR DESCRIPTION
## Summary
- add an IIS rewrite rule so requests for `assets/*` resolve to the SPA build output
- add a favicon rewrite rule to serve the icon directly from `dist/spa`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d75dcc3d348330af7ff9c785749e47