### PR TITLE
Allow anonymous browsing when Auth0 is disabled

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -16,6 +16,7 @@ import Bienestar from "./pages/Bienestar";
 import Formacion from "./pages/Formacion";
 import PoliticaCookies from "./pages/PoliticaCookies";
 import AvisoPrivacidad from "./pages/AvisoPrivacidad";
+import { authConfig } from "@/lib/auth-config";
 
 const queryClient = new QueryClient();
 
@@ -29,8 +30,12 @@ const App = () => (
           <ConditionalHeader />
           <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
+            {authConfig.isAuthEnabled ? (
+              <>
+                <Route path="/login" element={<Login />} />
+                <Route path="/register" element={<Register />} />
+              </>
+            ) : null}
             <Route path="/home" element={<Home />} />
             <Route path="/bienestar" element={<Bienestar />} />
             <Route path="/formacion" element={<Formacion />} />

--- a/client/components/ConditionalHeader.tsx
+++ b/client/components/ConditionalHeader.tsx
@@ -1,13 +1,16 @@
 import { useLocation } from "react-router-dom";
 
 import Header from "./Header";
-
-const hiddenPaths = new Set(["/login", "/register"]);
+import { useAuth } from "@/context/AuthContext";
 
 export default function ConditionalHeader() {
   const location = useLocation();
+  const { isAuthEnabled } = useAuth();
 
-  if (hiddenPaths.has(location.pathname)) {
+  if (
+    isAuthEnabled &&
+    (location.pathname === "/login" || location.pathname === "/register")
+  ) {
     return null;
   }
 

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header() {
   const [showPqrsSuccess, setShowPqrsSuccess] = useState(false);
   const [showMobileMenu, setShowMobileMenu] = useState(false);
   const navigate = useNavigate();
-  const { logout, user, isAuthenticated } = useAuth();
+  const { logout, user, isAuthenticated, isAuthEnabled } = useAuth();
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -79,24 +79,26 @@ export default function Header() {
             </button>
 
             {/* User greeting / Login link */}
-            {isAuthenticated ? (
-              <button className="flex h-[28px] px-4 items-center gap-4 rounded-[4px]">
-                <div className="flex py-[11px] items-center gap-2 self-stretch">
+            {isAuthEnabled ? (
+              isAuthenticated ? (
+                <button className="flex h-[28px] px-4 items-center gap-4 rounded-[4px]">
+                  <div className="flex py-[11px] items-center gap-2 self-stretch">
+                    <span className="text-[#FF1721] text-center font-['Source_Sans_Pro'] text-[14px] font-bold leading-[36px] tracking-[1.25px] uppercase">
+                      hola {greetingName}
+                    </span>
+                  </div>
+                </button>
+              ) : (
+                <Link
+                  to="/login"
+                  className="flex h-[28px] px-4 items-center gap-4 rounded-[4px]"
+                >
                   <span className="text-[#FF1721] text-center font-['Source_Sans_Pro'] text-[14px] font-bold leading-[36px] tracking-[1.25px] uppercase">
-                    hola {greetingName}
+                    iniciar sesión
                   </span>
-                </div>
-              </button>
-            ) : (
-              <Link
-                to="/login"
-                className="flex h-[28px] px-4 items-center gap-4 rounded-[4px]"
-              >
-                <span className="text-[#FF1721] text-center font-['Source_Sans_Pro'] text-[14px] font-bold leading-[36px] tracking-[1.25px] uppercase">
-                  iniciar sesión
-                </span>
-              </Link>
-            )}
+                </Link>
+              )
+            ) : null}
 
             {/* Contact Icon - positioned as in Figma */}
             <svg
@@ -137,7 +139,7 @@ export default function Header() {
           </div>
 
           {/* Logout Button */}
-          {isAuthenticated ? (
+          {isAuthEnabled && isAuthenticated ? (
             <button
               onClick={() => setShowLogout(true)}
               className="flex w-[177px] h-[36px] px-4 justify-center items-center gap-4 rounded-[50px] bg-[#FF1721]"
@@ -297,32 +299,34 @@ export default function Header() {
 
               <div className="w-full h-[1px] bg-[#E0E0E0] my-2"></div>
 
-              {isAuthenticated ? (
-                <button
-                  onClick={() => {
-                    setShowMobileMenu(false);
-                    setShowLogout(true);
-                  }}
-                  className="text-left text-[#FF1721] font-['Source_Sans_Pro'] text-[16px] font-bold py-2"
-                >
-                  CERRAR SESIÓN
-                </button>
-              ) : (
-                <Link
-                  to="/login"
-                  onClick={() => setShowMobileMenu(false)}
-                  className="text-left text-[#FF1721] font-['Source_Sans_Pro'] text-[16px] font-bold py-2"
-                >
-                  INICIAR SESIÓN
-                </Link>
-              )}
+              {isAuthEnabled ? (
+                isAuthenticated ? (
+                  <button
+                    onClick={() => {
+                      setShowMobileMenu(false);
+                      setShowLogout(true);
+                    }}
+                    className="text-left text-[#FF1721] font-['Source_Sans_Pro'] text-[16px] font-bold py-2"
+                  >
+                    CERRAR SESIÓN
+                  </button>
+                ) : (
+                  <Link
+                    to="/login"
+                    onClick={() => setShowMobileMenu(false)}
+                    className="text-left text-[#FF1721] font-['Source_Sans_Pro'] text-[16px] font-bold py-2"
+                  >
+                    INICIAR SESIÓN
+                  </Link>
+                )
+              ) : null}
             </div>
           </div>
         </div>
       )}
 
       {/* Logout Modal */}
-      {isAuthenticated && showLogout && (
+      {isAuthEnabled && isAuthenticated && showLogout && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center p-4"
           style={{ background: "rgba(14, 14, 14, 0.5)" }}

--- a/client/lib/auth-config.ts
+++ b/client/lib/auth-config.ts
@@ -1,0 +1,40 @@
+const normalizeFlagValue = (value?: string | boolean | null) => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) {
+      return true;
+    }
+
+    if (["false", "0", "no", "off"].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return undefined;
+};
+
+const readAuthEnabledFlag = () => {
+  let rawValue: string | boolean | null | undefined;
+
+  try {
+    rawValue = import.meta.env?.VITE_ENABLE_AUTH;
+  } catch (_error) {
+    rawValue = undefined;
+  }
+
+  const normalized = normalizeFlagValue(rawValue);
+
+  if (typeof normalized === "boolean") {
+    return normalized;
+  }
+
+  return false;
+};
+
+export const authConfig = {
+  isAuthEnabled: readAuthEnabledFlag(),
+} as const;

--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -3,6 +3,12 @@
     "rewrite": "/index.html",
     "exclude": ["/assets/*", "/favicon.ico", "/api/*"]
   },
+  "routes": [
+    {
+      "route": "/*",
+      "allowedRoles": ["anonymous", "authenticated"]
+    }
+  ],
   "responseOverrides": {
     "404": {
       "rewrite": "/index.html",


### PR DESCRIPTION
## Summary
- add a shared auth configuration helper to read the VITE_ENABLE_AUTH flag
- short-circuit the auth context and UI so login/register routes and controls disappear when authentication is disabled
- allow anonymous access in the static web apps configuration to avoid forced Auth0 redirects

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d76637d32c833095a13c53e9e99c47