### PR TITLE
Allow public access to demo API endpoint

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import express from "express";
-import cors from "cors";
+import cors, { CorsOptions } from "cors";
 import { handleDemo } from "./routes/demo";
 import { handleSendEmail } from "./routes/email";
 import { handleAuthLogin, handleAuthRegister } from "./routes/auth";
@@ -8,8 +8,22 @@ import { handleAuthLogin, handleAuthRegister } from "./routes/auth";
 export function createServer() {
   const app = express();
 
+  const corsOptions: CorsOptions = {
+    origin: "*",
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization", "Accept", "X-Requested-With"],
+    optionsSuccessStatus: 200,
+  };
+
   // Middleware
-  app.use(cors());
+  app.use(cors(corsOptions));
+  app.use((req, res, next) => {
+    if (req.method === "OPTIONS") {
+      res.sendStatus(200);
+      return;
+    }
+    next();
+  });
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
 

--- a/server/routes/demo.spec.ts
+++ b/server/routes/demo.spec.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { createServer } from "../index";
+
+const ORIGIN_HEADER = "https://example.com";
+
+describe("GET /api/demo", () => {
+  const app = createServer();
+  let server: Server | undefined;
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const address = server?.address() as AddressInfo | null;
+        if (!address) {
+          throw new Error("Failed to retrieve server address");
+        }
+        baseUrl = `http://127.0.0.1:${address.port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      if (!server) {
+        resolve();
+        return;
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  });
+
+  it("returns a public demo payload with permissive CORS headers", async () => {
+    const response = await fetch(`${baseUrl}/api/demo`, {
+      headers: {
+        Origin: ORIGIN_HEADER,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+    const body = await response.json();
+    expect(body).toEqual({ message: "Hello from Express server" });
+  });
+});

--- a/server/routes/demo.ts
+++ b/server/routes/demo.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from "express";
-import { DemoResponse } from "@shared/api";
+import type { DemoResponse } from "@shared/api";
 
 export const handleDemo: RequestHandler = (req, res) => {
   const response: DemoResponse = {


### PR DESCRIPTION
## Summary
- configure the Express server with permissive CORS options and handle OPTIONS requests to keep demo routes unrestricted
- update the demo handler to use type-only imports and avoid runtime resolution issues
- add a regression test that verifies `/api/demo` responds successfully with open CORS headers

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d7cd46630483309131ac7daf55169d