### PR TITLE
Fix server build target for Azure runtime

### DIFF
--- a/vite.config.server.ts
+++ b/vite.config.server.ts
@@ -11,7 +11,8 @@ export default defineConfig({
       formats: ["es"],
     },
     outDir: "dist/server",
-    target: "node22",
+    // Target a broadly supported Node.js runtime for Azure App Service deployments
+    target: "node18",
     ssr: true,
     rollupOptions: {
       external: [


### PR DESCRIPTION
## Summary
- lower the SSR build target to node18 to match Azure App Service supported runtimes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7ddf516cc8330a3ef8c2a29b982c1