### PR TITLE
Allow configuring API base URL for Azure deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ cp .env.example .env
 # Por defecto, el proyecto funciona sin configuración adicional
 ```
 
+#### Configurar la URL base del API en producción
+
+Cuando la aplicación web y el API se despliegan en hosts diferentes (por ejemplo, `https://mi-app.azurewebsites.net` para el
+frontend y `https://mi-api.azurewebsites.net` para el backend), define la variable `VITE_API_BASE_URL` en el entorno de build
+del cliente:
+
+```bash
+VITE_API_BASE_URL="https://mi-api.azurewebsites.net"
+```
+
+La aplicación utilizará automáticamente esta URL como prefijo para todas las llamadas al API (`/api/...`). Si la variable no se
+define, el cliente usará el mismo host en el que está alojada la SPA.
+
 ### 4. Iniciar el Servidor de Desarrollo
 
 ```bash

--- a/client/context/AuthContext.tsx
+++ b/client/context/AuthContext.tsx
@@ -8,6 +8,8 @@ import {
   type ReactNode,
 } from "react";
 
+import { apiFetch } from "@/lib/api-client";
+
 import { authConfig } from "@/lib/auth-config";
 
 import type {
@@ -177,7 +179,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setError(undefined);
 
       try {
-        const response = await fetch("/api/auth/login", {
+        const response = await apiFetch("/api/auth/login", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(credentials as LoginRequestBody),
@@ -224,7 +226,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setError(undefined);
 
       try {
-        const response = await fetch("/api/auth/register", {
+        const response = await apiFetch("/api/auth/register", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),

--- a/client/lib/api-client.ts
+++ b/client/lib/api-client.ts
@@ -1,0 +1,69 @@
+const normalizePath = (path: string) => {
+  if (!path) {
+    return "/";
+  }
+
+  return path.startsWith("/") ? path : `/${path}`;
+};
+
+const sanitizeUrlValue = (value: string) => value.replace(/\s+/g, "").replace(/\/+$/, "");
+
+const readApiBaseUrl = () => {
+  let rawValue: string | undefined;
+
+  try {
+    rawValue = import.meta.env?.VITE_API_BASE_URL;
+  } catch (_error) {
+    rawValue = undefined;
+  }
+
+  if (!rawValue) {
+    return "";
+  }
+
+  const trimmedValue = sanitizeUrlValue(rawValue);
+
+  if (!trimmedValue) {
+    return "";
+  }
+
+  try {
+    const url = new URL(trimmedValue);
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    return url.toString().replace(/\/+$/, "");
+  } catch (error) {
+    console.warn(
+      "El valor de VITE_API_BASE_URL no es una URL válida. Se utilizará el mismo host de la aplicación.",
+      error
+    );
+    return "";
+  }
+};
+
+const API_BASE_URL = readApiBaseUrl();
+
+export const createApiUrl = (path: string) => {
+  const normalizedPath = normalizePath(path);
+
+  if (!API_BASE_URL) {
+    return normalizedPath;
+  }
+
+  try {
+    return new URL(normalizedPath, `${API_BASE_URL}/`).toString();
+  } catch (error) {
+    console.warn(
+      `No se pudo construir la URL final para la ruta ${normalizedPath}. Se usará la ruta relativa.`,
+      error
+    );
+    return normalizedPath;
+  }
+};
+
+export const apiFetch: typeof fetch = (input, init) => {
+  if (typeof input === "string") {
+    return fetch(createApiUrl(input), init);
+  }
+
+  return fetch(input, init);
+};


### PR DESCRIPTION
## Summary
- add a reusable API client helper that honors the optional VITE_API_BASE_URL configuration
- switch authentication requests to use the helper so the SPA can call the backend when hosted on a different domain
- document how to configure the API base URL for production deployments

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db6a5e05148330b1f488dbc7fdec50