### PR TITLE
Handle environment variable rendering errors on Azure

### DIFF
--- a/server/routes/environment.ts
+++ b/server/routes/environment.ts
@@ -9,20 +9,64 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
+function normalizeValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    console.warn("No se pudo serializar el valor de una variable de entorno", error);
+    try {
+      return String(value);
+    } catch (stringifyError) {
+      console.warn("No se pudo convertir a texto el valor de una variable de entorno", stringifyError);
+      return "[Valor no disponible]";
+    }
+  }
+}
+
+function truncateValue(value: string, limit = 10_000): string {
+  if (value.length <= limit) {
+    return value;
+  }
+
+  return `${value.slice(0, limit)}… (truncated)`;
+}
+
 export const handleEnvironmentVariables: RequestHandler = (_req, res) => {
-  const entries = Object.entries(process.env)
-    .filter(([, value]) => value !== undefined)
-    .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+  try {
+    const entries = Object.entries(process.env)
+      .filter(([, value]) => value !== undefined)
+      .sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
 
-  const rows = entries
-    .map(([key, value]) => {
-      const safeKey = escapeHtml(key);
-      const safeValue = escapeHtml(String(value ?? ""));
-      return `<tr><th scope="row">${safeKey}</th><td>${safeValue}</td></tr>`;
-    })
-    .join("");
+    const rows = entries
+      .map(([key, rawValue]) => {
+        const safeKey = escapeHtml(key);
 
-  const html = `<!DOCTYPE html>
+        let normalizedValue: string;
+        try {
+          normalizedValue = truncateValue(normalizeValue(rawValue));
+        } catch (error) {
+          console.warn(`No se pudo normalizar la variable de entorno "${key}"`, error);
+          normalizedValue = "[Valor no disponible]";
+        }
+
+        const safeValue = escapeHtml(normalizedValue);
+        return `<tr><th scope="row">${safeKey}</th><td>${safeValue}</td></tr>`;
+      })
+      .join("");
+
+    const html = `<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -53,5 +97,25 @@ export const handleEnvironmentVariables: RequestHandler = (_req, res) => {
   </body>
 </html>`;
 
-  res.type("html").send(html);
+    res.type("html").send(html);
+  } catch (error) {
+    console.error("No se pudo renderizar la página de variables de entorno", error);
+    res.status(500).type("html").send(`<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Environment Variables</title>
+    <style>
+      body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; color: #0f172a; background-color: #f8fafc; }
+      h1 { font-size: 1.75rem; margin-bottom: 1.5rem; }
+      p { font-size: 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Environment Variables</h1>
+    <p>No se pudo mostrar la lista de variables de entorno. Revisa los registros del servidor para más detalles.</p>
+  </body>
+</html>`);
+  }
 };


### PR DESCRIPTION
## Summary
- normalize non-string environment variable values before rendering the /env table
- add truncation and error handling so the page degrades gracefully when serialization fails

## Testing
- pnpm build:server

------
https://chatgpt.com/codex/tasks/task_e_68dd2c7144cc833086bbf16b84aa7fb1