### PR TITLE
Document and externalize Builder.io public key configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,6 @@ AUTH0_DB_CONNECTION=
 
 # External API Keys (if needed in the future)
 # API_KEY=your_api_key_here
+
+# Builder.io public content API key used to fetch hosted assets
+VITE_PUBLIC_BUILDER_KEY=251da8f29625434a8c872a9913dedea9

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ VITE_API_BASE_URL="https://mi-api.azurewebsites.net"
 La aplicación utilizará automáticamente esta URL como prefijo para todas las llamadas al API (`/api/...`). Si la variable no se
 define, el cliente usará el mismo host en el que está alojada la SPA.
 
+#### Actualizar el contenido público de Builder.io
+
+Algunos enlaces a documentos legales se sirven desde Builder.io. La clave pública utilizada para descargar estos archivos se lee de la variable `VITE_PUBLIC_BUILDER_KEY`. Por defecto, el proyecto incluye la clave configurada actualmente, pero puedes reemplazarla en tu `.env`:
+
+```bash
+VITE_PUBLIC_BUILDER_KEY="tu-clave-publica"
+```
+
+El código del frontend utiliza esta variable para interpolar dinámicamente la clave en las URLs que apuntan a los activos almacenados en Builder.io, por lo que no necesitas modificar cada enlace manualmente cuando cambie la clave. En caso de que la variable no esté definida, se usa la clave por defecto incluida en el repositorio para mantener la compatibilidad.【F:client/lib/builder.ts†L1-L14】【F:client/pages/Home.tsx†L2-L3】【F:client/pages/Home.tsx†L182-L197】
+
 ### 4. Iniciar el Servidor de Desarrollo
 
 ```bash

--- a/client/lib/builder.ts
+++ b/client/lib/builder.ts
@@ -1,0 +1,16 @@
+const DEFAULT_BUILDER_PUBLIC_KEY = "251da8f29625434a8c872a9913dedea9";
+
+function normalizeEnvValue(rawValue: unknown): string | undefined {
+  if (typeof rawValue !== "string") {
+    return undefined;
+  }
+
+  const trimmed = rawValue.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const builderPublicKey = normalizeEnvValue(
+  typeof import.meta !== "undefined" ? import.meta.env?.VITE_PUBLIC_BUILDER_KEY : undefined,
+) ?? DEFAULT_BUILDER_PUBLIC_KEY;
+
+export const encodedBuilderPublicKey = encodeURIComponent(builderPublicKey);

--- a/client/pages/AvisoPrivacidad.tsx
+++ b/client/pages/AvisoPrivacidad.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
+import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+
 export default function AvisoPrivacidad() {
   return (
     <div className="min-h-screen bg-[#f0f0f0]">
@@ -626,7 +628,7 @@ export default function AvisoPrivacidad() {
                 }}
               >
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=${builderPublicKey}`}
                   download="Terminos-y-Condiciones.pdf"
                   target="_blank"
                   style={{
@@ -652,7 +654,7 @@ export default function AvisoPrivacidad() {
                   Política de Cookies
                 </div>
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=${builderPublicKey}`}
                   download="Politica-de-Privacidad.pdf"
                   target="_blank"
                   style={{

--- a/client/pages/Bienestar.tsx
+++ b/client/pages/Bienestar.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
+import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+
 export default function Bienestar() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
@@ -405,7 +407,7 @@ export default function Bienestar() {
             <div className="flex flex-col md:flex-row items-center justify-center md:justify-between w-full gap-4 md:gap-0">
               <nav className="flex flex-col md:flex-row items-center gap-4 md:gap-6 text-xs font-['Source_Sans_Pro'] leading-5 tracking-[0.4px] text-center">
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=${builderPublicKey}`}
                   download="Terminos-y-Condiciones.pdf"
                   target="_blank"
                   className="underline hover:no-underline"
@@ -416,7 +418,7 @@ export default function Bienestar() {
                   Política de Cookies
                 </a>
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=${builderPublicKey}`}
                   download="Politica-de-Privacidad.pdf"
                   target="_blank"
                   className="underline hover:no-underline"

--- a/client/pages/Formacion.tsx
+++ b/client/pages/Formacion.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
+import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+
 export default function Formacion() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [formData, setFormData] = useState({
@@ -325,7 +327,7 @@ export default function Formacion() {
             <div className="flex flex-col md:flex-row items-center justify-center md:justify-between w-full gap-4 md:gap-0">
               <nav className="flex flex-col md:flex-row items-center gap-4 md:gap-6 text-xs font-['Source_Sans_Pro'] leading-5 tracking-[0.4px] text-center">
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=${builderPublicKey}`}
                   download="Terminos-y-Condiciones.pdf"
                   target="_blank"
                   className="underline hover:no-underline"
@@ -339,7 +341,7 @@ export default function Formacion() {
                   Política de Cookies
                 </Link>
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=${builderPublicKey}`}
                   download="Politica-de-Privacidad.pdf"
                   target="_blank"
                   className="underline hover:no-underline"

--- a/client/pages/Home.tsx
+++ b/client/pages/Home.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+
+import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
 import { Link } from "react-router-dom";
 
 export default function Home() {
@@ -177,7 +179,7 @@ export default function Home() {
             <div className="flex flex-col md:flex-row items-center justify-center md:justify-between w-full gap-4 md:gap-0">
               <nav className="flex flex-col md:flex-row items-center gap-4 md:gap-6 text-xs font-['Source_Sans_Pro'] leading-5 tracking-[0.4px] text-center">
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=${builderPublicKey}`}
                   download="Terminos-y-Condiciones.pdf"
                   target="_blank"
                   className="underline hover:no-underline"
@@ -191,7 +193,7 @@ export default function Home() {
                   Política de Cookies
                 </Link>
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=${builderPublicKey}`}
                   download="Politica-de-Privacidad.pdf"
                   target="_blank"
                   className="underline hover:no-underline"

--- a/client/pages/PoliticaCookies.tsx
+++ b/client/pages/PoliticaCookies.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
+import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+
 export default function PoliticaCookies() {
   return (
     <div className="min-h-screen bg-[#f0f0f0]">
@@ -306,7 +308,7 @@ export default function PoliticaCookies() {
             <div className="flex items-center justify-between w-full">
               <nav className="flex items-center gap-6 text-xs font-['Source_Sans_Pro'] leading-5 tracking-[0.4px]">
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F8b1be5fcd60f49bdbfc969301f2ca7fc?alt=media&token=5022c0df-5c99-41c0-b448-2dd45d432ccc&apiKey=${builderPublicKey}`}
                   download="Terminos-y-Condiciones.pdf"
                   target="_blank"
                   className="underline hover:no-underline"
@@ -320,7 +322,7 @@ export default function PoliticaCookies() {
                   Política de Cookies
                 </Link>
                 <a
-                  href="https://cdn.builder.io/o/assets%2F251da8f29625434a8c872a9913dedea9%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=251da8f29625434a8c872a9913dedea9"
+                  href={`https://cdn.builder.io/o/assets%2F${encodedBuilderPublicKey}%2F42bed250c3b54cee8fe7078d269b6957?alt=media&token=b67a2eab-62c7-417a-9bf4-4ad68d3ac484&apiKey=${builderPublicKey}`}
                   download="Politica-de-Privacidad.pdf"
                   target="_blank"
                   className="underline hover:no-underline"


### PR DESCRIPTION
## Summary
- add a small builder helper that exposes the public key from VITE_PUBLIC_BUILDER_KEY with a sensible default
- interpolate the helper in legal page download links so the Builder.io key can be swapped without touching JSX
- document the environment variable in the sample env file and README so teams know how to update it

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68de7c3564088330a754a01052bfe5ff