### PR TITLE
Adjust header navigation padding to remove home banner gap

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -180,7 +180,7 @@ export default function Header() {
 
       {/* Navigation bar - Exact Figma spacing */}
       <nav className="hidden lg:block w-full bg-[#0c0e45]">
-        <div className="flex justify-center items-center gap-8 px-4 py-4 lg:px-[513px] lg:py-4">
+        <div className="flex justify-center items-center gap-8 px-4 pt-4 pb-0 lg:px-[513px] lg:pt-4 lg:pb-0">
           {/* HOME Button */}
           <button className="flex h-[28px] px-4 items-center gap-4 rounded-[4px]">
             <div className="flex py-[11px] items-center gap-2 self-stretch">


### PR DESCRIPTION
## Summary
- remove the navigation bar's bottom padding so the home banner sits flush with the menu

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deff1603948330ba96e1f842d7492e