### PR TITLE
Ensure login route is always available

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -30,11 +30,9 @@ const App = () => (
           <ConditionalHeader />
           <Routes>
             <Route path="/" element={<Home />} />
+            <Route path="/login" element={<Login />} />
             {authConfig.isAuthEnabled ? (
-              <>
-                <Route path="/login" element={<Login />} />
-                <Route path="/register" element={<Register />} />
-              </>
+              <Route path="/register" element={<Register />} />
             ) : null}
             <Route path="/home" element={<Home />} />
             <Route path="/bienestar" element={<Bienestar />} />


### PR DESCRIPTION
## Summary
- expose the login route regardless of the auth flag so /login renders the form
- keep the register page behind the optional auth feature flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df14071eec8330a7e17d8c431ae3f6