### PR TITLE
Enable authentication flag in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,4 +34,4 @@ AUTH0_CLIENT_SECRET=NUzdPuD_tVNY7GpsYUc8WhoPzpjppRI5Qq5rSHHIQYwjGyCTsot0T02Ycdge
 #AUTH0_AUDIENCE=
 # Database connection name configured in Auth0 (e.g. Username-Password-Authentication)
 #AUTH0_DB_CONNECTION=
-VITE_ENABLE_AUTH=false
+VITE_ENABLE_AUTH=true


### PR DESCRIPTION
## Summary
- set `VITE_ENABLE_AUTH` to true in `.env.example` so new environments enable authentication by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df174d7a748330b85fda3b2eebc179