### PR TITLE
Add env file generation to Azure pipeline

### DIFF
--- a/infra/azure-pipelines.yml
+++ b/infra/azure-pipelines.yml
@@ -53,6 +53,20 @@ stages:
           - script: npm ci
             displayName: "Install dependencies"
 
+          - pwsh: |
+              $envPath = "$(Build.SourcesDirectory)/.env"
+              $envLines = @(
+                "VITE_API_BASE_URL=$(VITE_API_BASE_URL)",
+                "VITE_ENABLE_AUTH=$(VITE_ENABLE_AUTH)",
+                "AUTH0_DOMAIN=$(AUTH0_DOMAIN)",
+                "AUTH0_CLIENT_ID=$(AUTH0_CLIENT_ID)",
+                "AUTH0_CLIENT_SECRET=$(AUTH0_CLIENT_SECRET)",
+                "AUTH0_DB_CONNECTION=$(AUTH0_DB_CONNECTION)"
+              )
+              $envLines | Set-Content -Path $envPath -Encoding utf8
+            displayName: "Generate .env from variable group"
+            condition: succeeded()
+
           - script: npm run build
             displayName: "Build application"
 


### PR DESCRIPTION
## Summary
- generate a .env file during the build job using the pipeline variable group so Vite receives the required configuration

## Testing
- not run (pipeline configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68dfd055f35083308231e99ae0d3164f