### PR TITLE
Add encrypted PQRS submission flow

### DIFF
--- a/client/lib/crypto.ts
+++ b/client/lib/crypto.ts
@@ -1,0 +1,53 @@
+export function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const cleaned = pem
+    .replace(/-----BEGIN PUBLIC KEY-----/g, "")
+    .replace(/-----END PUBLIC KEY-----/g, "")
+    .replace(/\s+/g, "");
+  const binaryString = globalThis.atob(cleaned);
+  const buffer = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i += 1) {
+    buffer[i] = binaryString.charCodeAt(i);
+  }
+  return buffer.buffer;
+}
+
+export async function importRsaPublicKey(pem: string): Promise<CryptoKey> {
+  const keyData = pemToArrayBuffer(pem);
+  return crypto.subtle.importKey(
+    "spki",
+    keyData,
+    {
+      name: "RSA-OAEP",
+      hash: "SHA-256",
+    },
+    false,
+    ["encrypt"],
+  );
+}
+
+export function stringToArrayBuffer(input: string): ArrayBuffer {
+  const encoder = new TextEncoder();
+  return encoder.encode(input).buffer;
+}
+
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return globalThis.btoa(binary);
+}
+
+export async function encryptJsonWithPublicKey(key: CryptoKey, payload: unknown): Promise<string> {
+  const json = JSON.stringify(payload);
+  const dataBuffer = stringToArrayBuffer(json);
+  const encrypted = await crypto.subtle.encrypt(
+    {
+      name: "RSA-OAEP",
+    },
+    key,
+    dataBuffer,
+  );
+  return arrayBufferToBase64(encrypted);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import { handleDemo } from "./routes/demo";
 import { handleSendEmail } from "./routes/email";
 import { handleAuthLogin, handleAuthRegister } from "./routes/auth";
 import { handleEnvironmentVariables } from "./routes/environment";
+import { handleGetPqrsPublicKey, handleSubmitPqrs } from "./routes/pqrs";
 import { requireAuth } from "./middleware/require-auth";
 
 export function createServer() {
@@ -43,6 +44,8 @@ export function createServer() {
   app.get("/env", handleEnvironmentVariables);
   app.get("/api/demo", requireAuth, handleDemo);
   app.post("/api/email/send", requireAuth, handleSendEmail);
+  app.get("/api/pqrs/public-key", handleGetPqrsPublicKey);
+  app.post("/api/pqrs", handleSubmitPqrs);
   app.post("/api/auth/register", handleAuthRegister);
   app.post("/api/auth/login", handleAuthLogin);
 

--- a/server/routes/pqrs.ts
+++ b/server/routes/pqrs.ts
@@ -1,0 +1,152 @@
+import { RequestHandler } from "express";
+import { privateDecrypt } from "node:crypto";
+import { z } from "zod";
+import { sendEmail } from "../services/email";
+import type {
+  PqrsFormData,
+  PqrsPublicKeyResponse,
+  PqrsSubmissionRequest,
+  PqrsSubmissionResponse,
+} from "@shared/api";
+
+const encryptedRequestSchema = z.object({
+  ciphertext: z.string().min(1, "Encrypted payload is required"),
+});
+
+const pqrsFormSchema = z.object({
+  fullName: z.string().min(1),
+  email: z.string().email(),
+  phone: z.string().min(1),
+  documentType: z.string().min(1),
+  documentNumber: z.string().min(1),
+  requestType: z.string().min(1),
+  subject: z.string().min(1),
+  description: z.string().min(1),
+});
+
+const normalizePem = (value: string): string => value.replace(/\\n/g, "\n");
+
+const decryptPayload = (ciphertext: string, privateKey: string): string => {
+  const decrypted = privateDecrypt(
+    {
+      key: normalizePem(privateKey),
+      oaepHash: "sha256",
+    },
+    Buffer.from(ciphertext, "base64"),
+  );
+  return decrypted.toString("utf-8");
+};
+
+const formatRecipients = (value: string | undefined): string[] =>
+  value?.split(",").map((entry) => entry.trim()).filter(Boolean) ?? [];
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const buildEmailContent = (data: PqrsFormData) => {
+  const html = `
+    <h1>Nueva solicitud PQRS</h1>
+    <p>Se ha recibido una nueva solicitud PQRS a través del portal.</p>
+    <h2>Datos personales</h2>
+    <ul>
+      <li><strong>Nombre:</strong> ${escapeHtml(data.fullName)}</li>
+      <li><strong>Correo:</strong> ${escapeHtml(data.email)}</li>
+      <li><strong>Teléfono:</strong> ${escapeHtml(data.phone)}</li>
+      <li><strong>Tipo de documento:</strong> ${escapeHtml(data.documentType)}</li>
+      <li><strong>Número de documento:</strong> ${escapeHtml(data.documentNumber)}</li>
+    </ul>
+    <h2>Detalle de la solicitud</h2>
+    <ul>
+      <li><strong>Tipo:</strong> ${escapeHtml(data.requestType)}</li>
+      <li><strong>Asunto:</strong> ${escapeHtml(data.subject)}</li>
+    </ul>
+    <p><strong>Descripción:</strong></p>
+    <p>${escapeHtml(data.description).replace(/\n/g, "<br />")}</p>
+  `;
+
+  const text = [
+    "Nueva solicitud PQRS",
+    "",
+    "Datos personales:",
+    `Nombre: ${data.fullName}`,
+    `Correo: ${data.email}`,
+    `Teléfono: ${data.phone}`,
+    `Tipo de documento: ${data.documentType}`,
+    `Número de documento: ${data.documentNumber}`,
+    "",
+    "Detalle de la solicitud:",
+    `Tipo: ${data.requestType}`,
+    `Asunto: ${data.subject}`,
+    "",
+    "Descripción:",
+    data.description,
+  ].join("\n");
+
+  return { html, text };
+};
+
+export const handleGetPqrsPublicKey: RequestHandler = (_req, res) => {
+  const publicKey = process.env.PQRS_PUBLIC_KEY;
+  if (!publicKey) {
+    return res.status(500).json({ error: "PQRS public key is not configured" });
+  }
+
+  const response: PqrsPublicKeyResponse = {
+    publicKey: normalizePem(publicKey),
+  };
+
+  res.json(response);
+};
+
+export const handleSubmitPqrs: RequestHandler = async (req, res) => {
+  const privateKey = process.env.PQRS_PRIVATE_KEY;
+  if (!privateKey) {
+    return res.status(500).json({ error: "PQRS private key is not configured" });
+  }
+
+  const parseEncrypted = encryptedRequestSchema.safeParse(req.body as PqrsSubmissionRequest);
+  if (!parseEncrypted.success) {
+    return res.status(400).json({ error: "Invalid request payload", details: parseEncrypted.error.flatten() });
+  }
+
+  let pqrsData: PqrsFormData;
+  try {
+    const decrypted = decryptPayload(parseEncrypted.data.ciphertext, privateKey);
+    const parsed = pqrsFormSchema.safeParse(JSON.parse(decrypted));
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid PQRS payload", details: parsed.error.flatten() });
+    }
+    pqrsData = parsed.data as PqrsFormData;
+  } catch (error) {
+    console.error("Failed to decrypt PQRS payload", error);
+    return res.status(400).json({ error: "Unable to decrypt PQRS payload" });
+  }
+
+  const recipients = formatRecipients(process.env.PQRS_EMAIL_TO);
+  if (recipients.length === 0) {
+    return res.status(500).json({ error: "PQRS_EMAIL_TO is not configured" });
+  }
+
+  const { html, text } = buildEmailContent(pqrsData);
+
+  try {
+    await sendEmail({
+      to: recipients,
+      subject: `Nueva solicitud PQRS - ${pqrsData.subject}`,
+      text,
+      html,
+      from: process.env.PQRS_EMAIL_FROM ?? undefined,
+    });
+  } catch (error) {
+    console.error("Failed to send PQRS email", error);
+    return res.status(502).json({ error: "Failed to send PQRS notification" });
+  }
+
+  const response: PqrsSubmissionResponse = { status: "ok" };
+  res.json(response);
+};

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -75,3 +75,26 @@ export interface LoginResponseBody {
   tokens: AuthTokens;
   user: Auth0UserProfile;
 }
+
+export interface PqrsFormData {
+  fullName: string;
+  email: string;
+  phone: string;
+  documentType: string;
+  documentNumber: string;
+  requestType: string;
+  subject: string;
+  description: string;
+}
+
+export interface PqrsSubmissionRequest {
+  ciphertext: string;
+}
+
+export interface PqrsSubmissionResponse {
+  status: "ok";
+}
+
+export interface PqrsPublicKeyResponse {
+  publicKey: string;
+}


### PR DESCRIPTION
## Summary
- capture PQRS form input on the client, encrypt it with the server-provided RSA key, and send it securely
- add shared PQRS data contracts plus crypto helpers for the browser
- expose backend endpoints to share the public key, decrypt submissions, and forward them via email

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e18f3df4f88330b423e7caeca30a90