### PR TITLE
Handle PKCS#1 PQRS public keys

### DIFF
--- a/client/lib/crypto.ts
+++ b/client/lib/crypto.ts
@@ -1,14 +1,95 @@
-export function pemToArrayBuffer(pem: string): ArrayBuffer {
-  const cleaned = pem
-    .replace(/-----BEGIN PUBLIC KEY-----/g, "")
-    .replace(/-----END PUBLIC KEY-----/g, "")
-    .replace(/\s+/g, "");
-  const binaryString = globalThis.atob(cleaned);
-  const buffer = new Uint8Array(binaryString.length);
+type PemKeyType = "PUBLIC KEY" | "RSA PUBLIC KEY";
+
+const RSA_ALGORITHM_IDENTIFIER = new Uint8Array([
+  0x30, 0x0d, // SEQUENCE length 0x0d
+  0x06, 0x09, // OID length 0x09
+  0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, // 1.2.840.113549.1.1.1 (rsaEncryption)
+  0x05, 0x00, // NULL
+]);
+
+const PEM_BOUNDARY_PATTERN = /-----BEGIN ([^-]+)-----([\s\S]+?)-----END \1-----/;
+
+const isSupportedKeyType = (value: string): value is PemKeyType =>
+  value === "PUBLIC KEY" || value === "RSA PUBLIC KEY";
+
+const decodeBase64 = (input: string): Uint8Array => {
+  const binaryString = globalThis.atob(input);
+  const output = new Uint8Array(binaryString.length);
   for (let i = 0; i < binaryString.length; i += 1) {
-    buffer[i] = binaryString.charCodeAt(i);
+    output[i] = binaryString.charCodeAt(i);
   }
-  return buffer.buffer;
+  return output;
+};
+
+const toArrayBuffer = (value: Uint8Array): ArrayBuffer => {
+  const buffer = new ArrayBuffer(value.byteLength);
+  new Uint8Array(buffer).set(value);
+  return buffer;
+};
+
+const encodeAsn1Length = (length: number): Uint8Array => {
+  if (length < 0x80) {
+    return new Uint8Array([length]);
+  }
+
+  const bytes: number[] = [];
+  let remaining = length;
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff);
+    remaining >>= 8;
+  }
+
+  return new Uint8Array([0x80 | bytes.length, ...bytes]);
+};
+
+const wrapPkcs1InSpki = (pkcs1: Uint8Array): Uint8Array => {
+  const bitStringLength = pkcs1.length + 1; // +1 for unused bits indicator
+  const bitStringLengthBytes = encodeAsn1Length(bitStringLength);
+  const bitString = new Uint8Array(1 + bitStringLengthBytes.length + bitStringLength);
+  bitString[0] = 0x03; // BIT STRING tag
+  bitString.set(bitStringLengthBytes, 1);
+  bitString[1 + bitStringLengthBytes.length] = 0x00; // unused bits indicator
+  bitString.set(pkcs1, 1 + bitStringLengthBytes.length + 1);
+
+  const sequenceLength = RSA_ALGORITHM_IDENTIFIER.length + bitString.length;
+  const sequenceLengthBytes = encodeAsn1Length(sequenceLength);
+  const spki = new Uint8Array(1 + sequenceLengthBytes.length + sequenceLength);
+  spki[0] = 0x30; // SEQUENCE tag
+  spki.set(sequenceLengthBytes, 1);
+  spki.set(RSA_ALGORITHM_IDENTIFIER, 1 + sequenceLengthBytes.length);
+  spki.set(bitString, 1 + sequenceLengthBytes.length + RSA_ALGORITHM_IDENTIFIER.length);
+
+  return spki;
+};
+
+export function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const trimmed = pem.trim();
+  const match = trimmed.match(PEM_BOUNDARY_PATTERN);
+  if (!match) {
+    if (trimmed.includes("-----BEGIN") || trimmed.includes("-----END")) {
+      throw new Error("Invalid PEM format");
+    }
+    const sanitized = trimmed.replace(/\s+/g, "");
+    if (!sanitized) {
+      throw new Error("Invalid PEM format");
+    }
+    return toArrayBuffer(decodeBase64(sanitized));
+  }
+
+  const [, rawType, body] = match;
+  const type = rawType.trim();
+  if (!isSupportedKeyType(type)) {
+    throw new Error(`Unsupported PEM key type: ${type}`);
+  }
+
+  const decoded = decodeBase64(body.replace(/\s+/g, ""));
+
+  if (type === "RSA PUBLIC KEY") {
+    const spki = wrapPkcs1InSpki(decoded);
+    return toArrayBuffer(spki);
+  }
+
+  return toArrayBuffer(decoded);
 }
 
 export async function importRsaPublicKey(pem: string): Promise<CryptoKey> {


### PR DESCRIPTION
## Summary
- support PQRS public keys provided as either SubjectPublicKeyInfo or PKCS#1 PEM
- wrap PKCS#1 keys in an RSA-OAEP compatible SPKI structure before importing in the browser
- add validation helpers for PEM parsing and copying into ArrayBuffers

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e19cb660908330a7aa8ce21f8538ba