### PR TITLE
Fix PQRS modal loading state reset

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -145,11 +145,13 @@ export default function Header() {
   const openPqrsModal = () => {
     setPqrsError(null);
     setPqrsKeyError(null);
+    setPqrsLoadingKey(false);
     setShowPqrs(true);
   };
 
   const closePqrsModal = () => {
     setShowPqrs(false);
+    setPqrsLoadingKey(false);
   };
 
   const isPqrsSubmitDisabled = pqrsSubmitting || pqrsLoadingKey || !!pqrsKeyError;


### PR DESCRIPTION
## Summary
- reset the PQRS loading indicator when opening or closing the modal so the submit button re-enables properly

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1a1cc000c8330b994a0c2dfd0596c