### PR TITLE
Fix PQRS secure submission loader lock-up

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -37,7 +37,7 @@ export default function Header() {
   }, [isAuthenticated]);
 
   useEffect(() => {
-    if (!showPqrs || pqrsPublicKey || pqrsLoadingKey) {
+    if (!showPqrs || pqrsPublicKey) {
       return;
     }
 
@@ -55,14 +55,12 @@ export default function Header() {
         const key = await importRsaPublicKey(data.publicKey);
         if (!cancelled) {
           setPqrsPublicKey(key);
+          setPqrsLoadingKey(false);
         }
       } catch (error) {
         console.error("Error fetching PQRS public key", error);
         if (!cancelled) {
           setPqrsKeyError("No fue posible preparar el envío seguro. Por favor, inténtalo más tarde.");
-        }
-      } finally {
-        if (!cancelled) {
           setPqrsLoadingKey(false);
         }
       }
@@ -73,7 +71,7 @@ export default function Header() {
     return () => {
       cancelled = true;
     };
-  }, [showPqrs, pqrsPublicKey, pqrsLoadingKey]);
+  }, [showPqrs, pqrsPublicKey]);
 
   const handlePqrsChange = (field: keyof PqrsFormData) =>
     (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {


### PR DESCRIPTION
## Summary
- adjust the PQRS modal effect to avoid cancelling the loader when the public key is fetched
- ensure the loading indicator clears whether the fetch succeeds or fails so the submit button becomes available

## Testing
- pnpm dev --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e1a7dd0b5083308316d16f6a40eb4f