### PR TITLE
Add encrypted formación course registration flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ PQRS_EMAIL_TO=pqrs@example.com
 # Optional sender override for PQRS notification emails
 PQRS_EMAIL_FROM=pqrs-notifier@example.com
 
+# Formación course inscription notifications
+FORMACION_EMAIL_TO=formacion@axapartners.com
+# Optional sender override for formación notifications
+#FORMACION_EMAIL_FROM=formacion-notifier@example.com
+
 # Auth0 tenant details for integration
 AUTH0_DOMAIN=axa-partners-colpatria-co-customers-dev.us.auth0.com
 AUTH0_CLIENT_ID=sApJYhUMEVH64YWfkXD9HZRn2IF5ZARq

--- a/client/pages/Formacion.tsx
+++ b/client/pages/Formacion.tsx
@@ -1,34 +1,175 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+import { encryptJsonWithPublicKey, importRsaPublicKey } from "@/lib/crypto";
+import type {
+  FormacionFormData,
+  FormacionPublicKeyResponse,
+  FormacionSubmissionResponse,
+} from "@shared/api";
+
+type FormacionFormState = Pick<FormacionFormData, "fullName" | "email">;
+
+type AlertMessage = {
+  type: "success" | "error";
+  message: string;
+};
 
 export default function Formacion() {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [formData, setFormData] = useState({
-    nombre: "",
+  const [selectedCourse, setSelectedCourse] = useState<string | null>(null);
+  const [formData, setFormData] = useState<FormacionFormState>({
+    fullName: "",
     email: "",
   });
+  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [publicKey, setPublicKey] = useState<CryptoKey | null>(null);
+  const [loadingKey, setLoadingKey] = useState(false);
+  const [keyError, setKeyError] = useState<string | null>(null);
+  const [alertMessage, setAlertMessage] = useState<AlertMessage | null>(null);
 
-  const openModal = () => setIsModalOpen(true);
+  const openModal = (course: string) => {
+    setSelectedCourse(course);
+    setIsModalOpen(true);
+    setFormError(null);
+    if (keyError) {
+      setKeyError(null);
+      setPublicKey(null);
+    }
+  };
+
   const closeModal = () => {
     setIsModalOpen(false);
-    setFormData({ nombre: "", email: "" });
+    setSelectedCourse(null);
+    setFormData({ fullName: "", email: "" });
+    setFormError(null);
+    setFormSubmitting(false);
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({
+      ...previous,
+      [name as keyof FormacionFormState]: value,
+    }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    // Handle form submission here
-    console.log("Form submitted:", formData);
-    closeModal();
+  const handleRetryLoadKey = () => {
+    setKeyError(null);
+    setPublicKey(null);
   };
+
+  useEffect(() => {
+    if (!isModalOpen || loadingKey || publicKey || keyError) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchPublicKey = async () => {
+      setLoadingKey(true);
+      try {
+        const response = await fetch("/api/formacion/public-key");
+        if (!response.ok) {
+          throw new Error("No se pudo obtener la llave pública.");
+        }
+        const data = (await response.json()) as FormacionPublicKeyResponse;
+        if (cancelled) {
+          return;
+        }
+        const key = await importRsaPublicKey(data.publicKey);
+        if (cancelled) {
+          return;
+        }
+        setPublicKey(key);
+      } catch (error) {
+        console.error("Failed to load formación public key", error);
+        if (!cancelled) {
+          setKeyError("No pudimos preparar el formulario. Intenta nuevamente.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingKey(false);
+        }
+      }
+    };
+
+    void fetchPublicKey();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isModalOpen, loadingKey, publicKey, keyError]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedCourse) {
+      setFormError("Selecciona un curso antes de enviar tu inscripción.");
+      return;
+    }
+
+    if (!publicKey) {
+      setFormError("No pudimos preparar la inscripción. Intenta nuevamente.");
+      return;
+    }
+
+    setFormSubmitting(true);
+    setFormError(null);
+
+    try {
+      const payload: FormacionFormData = {
+        fullName: formData.fullName.trim(),
+        email: formData.email.trim(),
+        course: selectedCourse,
+      };
+
+      const encryptedPayload = await encryptJsonWithPublicKey(publicKey, payload);
+
+      const response = await fetch("/api/formacion", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(encryptedPayload),
+      });
+
+      const responseBody = (await response
+        .json()
+        .catch(() => null)) as FormacionSubmissionResponse | { error?: string } | null;
+
+      if (!response.ok) {
+        const message =
+          responseBody && typeof responseBody === "object" && "error" in responseBody && responseBody.error
+            ? responseBody.error
+            : "No se pudo completar la inscripción. Intenta nuevamente.";
+        throw new Error(message);
+      }
+
+      if (!responseBody || (responseBody as FormacionSubmissionResponse).status !== "ok") {
+        throw new Error("No recibimos confirmación de la inscripción. Intenta nuevamente.");
+      }
+
+      setAlertMessage({
+        type: "success",
+        message: "Tu inscripción fue enviada correctamente. Pronto nos pondremos en contacto contigo.",
+      });
+      closeModal();
+    } catch (error) {
+      console.error("Error submitting formación form", error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Ocurrió un error inesperado al enviar tu inscripción. Intenta nuevamente.";
+      setFormError(message);
+    } finally {
+      setFormSubmitting(false);
+    }
+  };
+
+  const isSubmitDisabled = formSubmitting || loadingKey || !!keyError;
 
   return (
     <div className="min-h-screen bg-[#f0f0f0]">
@@ -94,6 +235,18 @@ export default function Formacion() {
             <div className="w-[177px] h-[2px] bg-[#6574f8] mx-auto"></div>
           </div>
 
+          {alertMessage && (
+            <div
+              className={`mb-6 rounded-lg border px-4 py-3 text-sm font-['Source_Sans_Pro'] ${
+                alertMessage.type === "success"
+                  ? "border-green-500 bg-green-50 text-green-700"
+                  : "border-[#FF1721] bg-red-50 text-[#a1131a]"
+              }`}
+            >
+              {alertMessage.message}
+            </div>
+          )}
+
           {/* Courses Grid - Only 3 courses */}
           <div className="flex flex-col md:flex-row items-center gap-5 justify-center">
             {/* Educación Digital Card */}
@@ -149,7 +302,7 @@ export default function Formacion() {
                   potencian tus habilidades digitales.
                 </p>
                 <button
-                  onClick={openModal}
+                  onClick={() => openModal("Educación Digital")}
                   className="text-[#0c0e45] font-['Source_Sans_Pro'] text-sm font-bold leading-9 tracking-[1.25px] uppercase hover:underline"
                 >
                   INSCRIBIRME AL CURSO
@@ -198,7 +351,7 @@ export default function Formacion() {
                   planificación financiera.
                 </p>
                 <button
-                  onClick={openModal}
+                  onClick={() => openModal("Educación Financiera")}
                   className="text-[#0c0e45] font-['Source_Sans_Pro'] text-sm font-bold leading-9 tracking-[1.25px] uppercase hover:underline"
                 >
                   INSCRIBIRME AL CURSO
@@ -247,7 +400,7 @@ export default function Formacion() {
                   para hacer crecer tu negocio.
                 </p>
                 <button
-                  onClick={openModal}
+                  onClick={() => openModal("Marketing Digital")}
                   className="text-[#0c0e45] font-['Source_Sans_Pro'] text-sm font-bold leading-9 tracking-[1.25px] uppercase hover:underline"
                 >
                   INSCRIBIRME AL CURSO
@@ -381,8 +534,19 @@ export default function Formacion() {
                   Regístrate fácilmente y asegura tu lugar en el curso que
                   impulsará tu desarrollo.
                 </p>
-              </div>
             </div>
+          </div>
+
+            {selectedCourse && (
+              <div className="mb-6 rounded-[12px] bg-[#f0f0f0] px-4 py-3">
+                <p className="text-xs font-['Source_Sans_Pro'] font-semibold uppercase tracking-[1.25px] text-[#0c0e45]">
+                  Curso seleccionado
+                </p>
+                <p className="mt-1 text-[#0e0e0e] font-['Source_Sans_Pro'] text-base leading-6">
+                  {selectedCourse}
+                </p>
+              </div>
+            )}
 
             {/* Form */}
             <form onSubmit={handleSubmit} className="space-y-6">
@@ -397,11 +561,13 @@ export default function Formacion() {
                   <div className="relative">
                     <input
                       type="text"
-                      name="nombre"
-                      value={formData.nombre}
+                      name="fullName"
+                      value={formData.fullName}
                       onChange={handleInputChange}
                       placeholder="Nombre y apellido"
-                      className="w-full h-14 px-3 py-2 border border-black/42 rounded focus:outline-none focus:border-[#0c0e45] text-[#0e0e0e] font-['Source_Sans_Pro'] text-base leading-6 tracking-[0.5px]"
+                      autoComplete="name"
+                      disabled={formSubmitting}
+                      className="w-full h-14 px-3 py-2 border border-black/42 rounded focus:outline-none focus:border-[#0c0e45] text-[#0e0e0e] font-['Source_Sans_Pro'] text-base leading-6 tracking-[0.5px] disabled:bg-gray-100"
                       required
                     />
                   </div>
@@ -414,28 +580,55 @@ export default function Formacion() {
                       value={formData.email}
                       onChange={handleInputChange}
                       placeholder="correo electrónico"
-                      className="w-full h-14 px-3 py-2 border border-black/42 rounded focus:outline-none focus:border-[#0c0e45] text-[#0e0e0e] font-['Source_Sans_Pro'] text-base leading-6 tracking-[0.5px]"
+                      autoComplete="email"
+                      disabled={formSubmitting}
+                      className="w-full h-14 px-3 py-2 border border-black/42 rounded focus:outline-none focus:border-[#0c0e45] text-[#0e0e0e] font-['Source_Sans_Pro'] text-base leading-6 tracking-[0.5px] disabled:bg-gray-100"
                       required
                     />
                   </div>
                 </div>
               </div>
 
+              {loadingKey && !keyError && (
+                <p className="text-xs text-[#666] font-['Source_Sans_Pro']">
+                  Preparando la información para el envío seguro…
+                </p>
+              )}
+
+              {keyError && (
+                <div className="rounded-md bg-red-50 px-3 py-2 text-sm text-[#a1131a] font-['Source_Sans_Pro']">
+                  {keyError}
+                  <button
+                    type="button"
+                    onClick={handleRetryLoadKey}
+                    className="ml-2 font-semibold underline hover:no-underline"
+                  >
+                    Reintentar
+                  </button>
+                </div>
+              )}
+
+              {formError && (
+                <p className="text-sm text-[#FF1721] font-['Source_Sans_Pro']">{formError}</p>
+              )}
+
               {/* Buttons */}
               <div className="space-y-3 pt-6">
                 {/* Submit Button */}
                 <button
                   type="submit"
-                  className="w-full h-11 bg-[#0c0e45] text-white font-['Source_Sans_Pro'] text-sm font-bold leading-9 tracking-[1.25px] uppercase rounded-full hover:bg-[#0a0c3a] transition-colors"
+                  disabled={isSubmitDisabled}
+                  className="w-full h-11 bg-[#0c0e45] text-white font-['Source_Sans_Pro'] text-sm font-bold leading-9 tracking-[1.25px] uppercase rounded-full hover:bg-[#0a0c3a] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  INSCRIBIRSE
+                  {formSubmitting ? "ENVIANDO…" : "INSCRIBIRSE"}
                 </button>
 
                 {/* Cancel Button */}
                 <button
                   type="button"
                   onClick={closeModal}
-                  className="w-full h-11 bg-white border border-[#0c0e45] text-[#0c0e45] font-['Source_Sans_Pro'] text-sm font-bold leading-9 tracking-[1.25px] uppercase rounded-full hover:bg-gray-50 transition-colors"
+                  disabled={formSubmitting}
+                  className="w-full h-11 bg-white border border-[#0c0e45] text-[#0c0e45] font-['Source_Sans_Pro'] text-sm font-bold leading-9 tracking-[1.25px] uppercase rounded-full hover:bg-gray-50 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   CANCELAR
                 </button>

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { handleSendEmail } from "./routes/email";
 import { handleAuthLogin, handleAuthRegister } from "./routes/auth";
 import { handleEnvironmentVariables } from "./routes/environment";
 import { handleGetPqrsPublicKey, handleSubmitPqrs } from "./routes/pqrs";
+import { handleGetFormacionPublicKey, handleSubmitFormacion } from "./routes/formacion";
 import { requireAuth } from "./middleware/require-auth";
 
 export function createServer() {
@@ -46,6 +47,8 @@ export function createServer() {
   app.post("/api/email/send", requireAuth, handleSendEmail);
   app.get("/api/pqrs/public-key", handleGetPqrsPublicKey);
   app.post("/api/pqrs", handleSubmitPqrs);
+  app.get("/api/formacion/public-key", handleGetFormacionPublicKey);
+  app.post("/api/formacion", handleSubmitFormacion);
   app.post("/api/auth/register", handleAuthRegister);
   app.post("/api/auth/login", handleAuthLogin);
 

--- a/server/routes/formacion.ts
+++ b/server/routes/formacion.ts
@@ -1,0 +1,110 @@
+import { RequestHandler } from "express";
+import { z } from "zod";
+
+import {
+  decryptPayload,
+  encryptedRequestSchema,
+  escapeHtml,
+  formatRecipients,
+  normalizePem,
+} from "./utils/encrypted-request";
+import { sendEmail } from "../services/email";
+import type {
+  FormacionFormData,
+  FormacionPublicKeyResponse,
+  FormacionSubmissionRequest,
+  FormacionSubmissionResponse,
+} from "@shared/api";
+
+const formacionFormSchema = z.object({
+  fullName: z.string().min(1),
+  email: z.string().email(),
+  course: z.string().min(1),
+});
+
+type _EncryptedRequestMatchesSchema = FormacionSubmissionRequest extends z.infer<typeof encryptedRequestSchema>
+  ? true
+  : never;
+
+const buildEmailContent = (data: FormacionFormData) => {
+  const html = `
+    <h1>Nueva inscripción a curso</h1>
+    <p>Se ha recibido una nueva inscripción a través del portal de formación.</p>
+    <ul>
+      <li><strong>Nombre:</strong> ${escapeHtml(data.fullName)}</li>
+      <li><strong>Correo:</strong> ${escapeHtml(data.email)}</li>
+      <li><strong>Curso seleccionado:</strong> ${escapeHtml(data.course)}</li>
+    </ul>
+  `;
+
+  const text = [
+    "Nueva inscripción a curso",
+    "",
+    `Nombre: ${data.fullName}`,
+    `Correo: ${data.email}`,
+    `Curso seleccionado: ${data.course}`,
+  ].join("\n");
+
+  return { html, text };
+};
+
+export const handleGetFormacionPublicKey: RequestHandler = (_req, res) => {
+  const publicKey = process.env.PQRS_PUBLIC_KEY;
+  if (!publicKey) {
+    return res.status(500).json({ error: "PQRS public key is not configured" });
+  }
+
+  const response: FormacionPublicKeyResponse = {
+    publicKey: normalizePem(publicKey),
+  };
+
+  res.json(response);
+};
+
+export const handleSubmitFormacion: RequestHandler = async (req, res) => {
+  const privateKey = process.env.PQRS_PRIVATE_KEY;
+  if (!privateKey) {
+    return res.status(500).json({ error: "PQRS private key is not configured" });
+  }
+
+  const parseEncrypted = encryptedRequestSchema.safeParse(req.body);
+  if (!parseEncrypted.success) {
+    return res.status(400).json({ error: "Invalid request payload", details: parseEncrypted.error.flatten() });
+  }
+
+  let formData: FormacionFormData;
+  try {
+    const decrypted = decryptPayload(parseEncrypted.data, privateKey);
+    const parsed = formacionFormSchema.safeParse(JSON.parse(decrypted));
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid form payload", details: parsed.error.flatten() });
+    }
+    formData = parsed.data;
+  } catch (error) {
+    console.error("Failed to decrypt formación payload", error);
+    return res.status(400).json({ error: "Unable to decrypt form payload" });
+  }
+
+  const recipients = formatRecipients(process.env.FORMACION_EMAIL_TO);
+  if (recipients.length === 0) {
+    return res.status(500).json({ error: "FORMACION_EMAIL_TO is not configured" });
+  }
+
+  const { html, text } = buildEmailContent(formData);
+
+  try {
+    await sendEmail({
+      to: recipients,
+      subject: `Nueva inscripción curso - ${formData.course}`,
+      text,
+      html,
+      from: process.env.FORMACION_EMAIL_FROM ?? process.env.PQRS_EMAIL_FROM ?? undefined,
+    });
+  } catch (error) {
+    console.error("Failed to send formación email", error);
+    return res.status(502).json({ error: "Failed to send formación notification" });
+  }
+
+  const response: FormacionSubmissionResponse = { status: "ok" };
+  res.json(response);
+};

--- a/server/routes/utils/encrypted-request.ts
+++ b/server/routes/utils/encrypted-request.ts
@@ -1,0 +1,57 @@
+import { createDecipheriv, privateDecrypt } from "node:crypto";
+import { z } from "zod";
+
+import type { EncryptedSubmissionRequest } from "@shared/api";
+
+export const encryptedRequestSchema = z.object({
+  ciphertext: z.string().min(1, "Encrypted payload is required"),
+  encryptedKey: z.string().min(1, "Encrypted key is required"),
+  iv: z.string().min(1, "Initialization vector is required"),
+});
+
+const AUTH_TAG_LENGTH = 16;
+
+export const normalizePem = (value: string): string => value.replace(/\\n/g, "\n");
+
+export const decryptPayload = (
+  payload: EncryptedSubmissionRequest,
+  privateKey: string,
+): string => {
+  const aesKey = privateDecrypt(
+    {
+      key: normalizePem(privateKey),
+      oaepHash: "sha256",
+    },
+    Buffer.from(payload.encryptedKey, "base64"),
+  );
+
+  const ciphertext = Buffer.from(payload.ciphertext, "base64");
+  if (ciphertext.length <= AUTH_TAG_LENGTH) {
+    throw new Error("Ciphertext is too short");
+  }
+
+  const authTag = ciphertext.subarray(ciphertext.length - AUTH_TAG_LENGTH);
+  const encrypted = ciphertext.subarray(0, ciphertext.length - AUTH_TAG_LENGTH);
+  const iv = Buffer.from(payload.iv, "base64");
+
+  const decipher = createDecipheriv("aes-256-gcm", aesKey, iv);
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString("utf-8");
+};
+
+export const formatRecipients = (value: string | undefined): string[] =>
+  value?.split(",").map((entry) => entry.trim()).filter(Boolean) ?? [];
+
+export const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+export type EncryptedRequestSchema = typeof encryptedRequestSchema;
+
+export type ParsedEncryptedRequest = z.infer<typeof encryptedRequestSchema>;

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -87,11 +87,15 @@ export interface PqrsFormData {
   description: string;
 }
 
-export interface PqrsSubmissionRequest {
+export interface EncryptedSubmissionRequest {
   ciphertext: string;
   encryptedKey: string;
   iv: string;
 }
+
+export interface PqrsSubmissionRequest extends EncryptedSubmissionRequest {}
+
+export type FormacionSubmissionRequest = EncryptedSubmissionRequest;
 
 export interface PqrsSubmissionResponse {
   status: "ok";
@@ -100,3 +104,13 @@ export interface PqrsSubmissionResponse {
 export interface PqrsPublicKeyResponse {
   publicKey: string;
 }
+
+export interface FormacionFormData {
+  fullName: string;
+  email: string;
+  course: string;
+}
+
+export type FormacionSubmissionResponse = PqrsSubmissionResponse;
+
+export type FormacionPublicKeyResponse = PqrsPublicKeyResponse;


### PR DESCRIPTION
## Summary
- add encrypted course enrollment modal submission on the formación page using the existing PQRS keys and provide user feedback
- introduce shared encrypted form utilities plus formación API endpoints that decrypt submissions and send notification emails
- expand shared API types and environment configuration to support formación enrolment handling

## Testing
- pnpm test *(fails: GET /api/demo requires authentication and returns 401 in the current setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b18d67cc83308c1de20fece4a440