### PR TITLE
Fix PQRS and formación forms API requests

### DIFF
--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
+import { apiFetch } from "@/lib/api-client";
 import { encryptJsonWithPublicKey, importRsaPublicKey } from "@/lib/crypto";
 import type { PqrsFormData } from "@shared/api";
 
@@ -47,7 +48,7 @@ export default function Header() {
       setPqrsKeyError(null);
       setPqrsLoadingKey(true);
       try {
-        const response = await fetch("/api/pqrs/public-key");
+        const response = await apiFetch("/api/pqrs/public-key");
         if (!response.ok) {
           throw new Error(`Error al obtener la llave pública (${response.status})`);
         }
@@ -113,7 +114,7 @@ export default function Header() {
     try {
       setPqrsSubmitting(true);
       const encryptedPayload = await encryptJsonWithPublicKey(pqrsPublicKey, pqrsForm);
-      const response = await fetch("/api/pqrs", {
+      const response = await apiFetch("/api/pqrs", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/client/pages/Formacion.tsx
+++ b/client/pages/Formacion.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+import { apiFetch } from "@/lib/api-client";
 import { encryptJsonWithPublicKey, importRsaPublicKey } from "@/lib/crypto";
 import type {
   FormacionFormData,
@@ -74,7 +75,7 @@ export default function Formacion() {
     const fetchPublicKey = async () => {
       setLoadingKey(true);
       try {
-        const response = await fetch("/api/formacion/public-key");
+        const response = await apiFetch("/api/formacion/public-key");
         if (!response.ok) {
           throw new Error("No se pudo obtener la llave pública.");
         }
@@ -131,7 +132,7 @@ export default function Formacion() {
 
       const encryptedPayload = await encryptJsonWithPublicKey(publicKey, payload);
 
-      const response = await fetch("/api/formacion", {
+      const response = await apiFetch("/api/formacion", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- use the shared API client helper for PQRS form requests so they respect the configured base URL
- update formación form API calls to go through the shared API client as well

## Testing
- pnpm typecheck *(fails: existing type errors in server routes)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d579f98883308892d2995e88fabd