### PR TITLE
Adjust formación key configuration to support dedicated env vars

### DIFF
--- a/server/routes/formacion.ts
+++ b/server/routes/formacion.ts
@@ -49,9 +49,9 @@ const buildEmailContent = (data: FormacionFormData) => {
 };
 
 export const handleGetFormacionPublicKey: RequestHandler = (_req, res) => {
-  const publicKey = process.env.PQRS_PUBLIC_KEY;
+  const publicKey = process.env.FORMACION_PUBLIC_KEY ?? process.env.PQRS_PUBLIC_KEY;
   if (!publicKey) {
-    return res.status(500).json({ error: "PQRS public key is not configured" });
+    return res.status(500).json({ error: "FORMACION public key is not configured" });
   }
 
   const response: FormacionPublicKeyResponse = {
@@ -62,9 +62,9 @@ export const handleGetFormacionPublicKey: RequestHandler = (_req, res) => {
 };
 
 export const handleSubmitFormacion: RequestHandler = async (req, res) => {
-  const privateKey = process.env.PQRS_PRIVATE_KEY;
+  const privateKey = process.env.FORMACION_PRIVATE_KEY ?? process.env.PQRS_PRIVATE_KEY;
   if (!privateKey) {
-    return res.status(500).json({ error: "PQRS private key is not configured" });
+    return res.status(500).json({ error: "FORMACION private key is not configured" });
   }
 
   const parseEncrypted = encryptedRequestSchema.safeParse(req.body);


### PR DESCRIPTION
## Summary
- allow the formación public key endpoint to use FORMACION_PUBLIC_KEY with a fallback to PQRS_PUBLIC_KEY
- update formación submission handler to read FORMACION_PRIVATE_KEY before falling back to PQRS_PRIVATE_KEY
- return formación-specific configuration error messages when keys are missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d72b5a6c83309513908afd420a45