### PR TITLE
Use formación-specific key environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ PQRS_EMAIL_TO=pqrs@example.com
 PQRS_EMAIL_FROM=pqrs-notifier@example.com
 
 # Formación course inscription notifications
+# Provide the RSA key pair used to encrypt submissions from the formación form.
+FORMACION_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvExampleFormacionPublicKey\n-----END PUBLIC KEY-----"
+FORMACION_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC8ExampleFormacionPrivateKey\n-----END PRIVATE KEY-----"
 FORMACION_EMAIL_TO=formacion@axapartners.com
 # Optional sender override for formación notifications
 #FORMACION_EMAIL_FROM=formacion-notifier@example.com

--- a/server/routes/formacion.ts
+++ b/server/routes/formacion.ts
@@ -49,7 +49,7 @@ const buildEmailContent = (data: FormacionFormData) => {
 };
 
 export const handleGetFormacionPublicKey: RequestHandler = (_req, res) => {
-  const publicKey = process.env.PQRS_PUBLIC_KEY;
+  const publicKey = process.env.FORMACION_PUBLIC_KEY;
   if (!publicKey) {
     return res.status(500).json({ error: "FORMACION public key is not configured" });
   }
@@ -62,7 +62,7 @@ export const handleGetFormacionPublicKey: RequestHandler = (_req, res) => {
 };
 
 export const handleSubmitFormacion: RequestHandler = async (req, res) => {
-  const privateKey = process.env.PQRS_PRIVATE_KEY;
+  const privateKey = process.env.FORMACION_PRIVATE_KEY;
   if (!privateKey) {
     return res.status(500).json({ error: "FORMACION private key is not configured" });
   }


### PR DESCRIPTION
## Summary
- switch the formación public/private key handlers to read FORMACION_* env vars
- document the formación RSA key configuration in the environment example file

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1da652ba4833093b785fd502fa484