### PR TITLE
Fix formación form key loading

### DIFF
--- a/client/pages/Formacion.tsx
+++ b/client/pages/Formacion.tsx
@@ -29,6 +29,7 @@ export default function Formacion() {
   const [publicKey, setPublicKey] = useState<CryptoKey | null>(null);
   const [loadingKey, setLoadingKey] = useState(false);
   const [keyError, setKeyError] = useState<string | null>(null);
+  const [keyRetryToken, setKeyRetryToken] = useState(0);
   const [alertMessage, setAlertMessage] = useState<AlertMessage | null>(null);
 
   const openModal = (course: string) => {
@@ -63,6 +64,7 @@ export default function Formacion() {
   const handleRetryLoadKey = () => {
     setKeyError(null);
     setPublicKey(null);
+    setKeyRetryToken((token) => token + 1);
   };
 
   useEffect(() => {
@@ -105,7 +107,7 @@ export default function Formacion() {
     return () => {
       cancelled = true;
     };
-  }, [isModalOpen, loadingKey, publicKey, keyError]);
+  }, [isModalOpen, keyRetryToken]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- prevent the formación modal from cancelling the public key request when the loading state toggles
- add an explicit retry trigger so the "Reintentar" action starts a new key fetch after clearing errors

## Testing
- pnpm typecheck *(fails: existing server route type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e1dc36bf0883308f21c75fbc2f9ec8