### PR TITLE
Handle multiple separators in formación email recipients

### DIFF
--- a/server/routes/utils/encrypted-request.ts
+++ b/server/routes/utils/encrypted-request.ts
@@ -42,7 +42,10 @@ export const decryptPayload = (
 };
 
 export const formatRecipients = (value: string | undefined): string[] =>
-  value?.split(",").map((entry) => entry.trim()).filter(Boolean) ?? [];
+  value
+    ?.split(/[\s,;]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean) ?? [];
 
 export const escapeHtml = (value: string): string =>
   value


### PR DESCRIPTION
## Summary
- allow the formación email recipient parser to accept comma, semicolon, and whitespace separated lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f79c47c48330a7e993123b2935b9