### PR TITLE
Update SIA token handling for new API response

### DIFF
--- a/client/pages/Bienestar.tsx
+++ b/client/pages/Bienestar.tsx
@@ -96,10 +96,13 @@ const isSiaTokenResponse = (value: unknown): value is SiaTokenResponse => {
 
   const record = value as Record<string, unknown>;
 
+  const expiresIn = record.expires_in;
+
   return (
-    typeof record.sia_token === "string" &&
-    typeof record.sia_dz === "string" &&
-    typeof record.sia_consumer_key === "string"
+    typeof record.access_token === "string" &&
+    typeof record.token_type === "string" &&
+    typeof expiresIn === "number" &&
+    Number.isFinite(expiresIn)
   );
 };
 
@@ -1024,14 +1027,44 @@ export default function Bienestar() {
                     {siaTokenData ? (
                       <div className="rounded-[6px] border border-[#0c0e45]/30 bg-[#f4f5ff] px-3 py-2 text-xs text-[#0e0e0e] space-y-1 break-all">
                         <p>
-                          <span className="font-semibold">sia_token:</span> {siaTokenData.sia_token}
+                          <span className="font-semibold">access_token:</span> {siaTokenData.access_token}
                         </p>
                         <p>
-                          <span className="font-semibold">sia_dz:</span> {siaTokenData.sia_dz}
+                          <span className="font-semibold">token_type:</span> {siaTokenData.token_type}
                         </p>
                         <p>
-                          <span className="font-semibold">sia_consumer_key:</span> {siaTokenData.sia_consumer_key}
+                          <span className="font-semibold">expires_in:</span> {siaTokenData.expires_in}
                         </p>
+                        {siaTokenData.uid ? (
+                          <p>
+                            <span className="font-semibold">uid:</span> {siaTokenData.uid}
+                          </p>
+                        ) : null}
+                        {siaTokenData.ulogin ? (
+                          <p>
+                            <span className="font-semibold">ulogin:</span> {siaTokenData.ulogin}
+                          </p>
+                        ) : null}
+                        {siaTokenData.consumerKey ? (
+                          <p>
+                            <span className="font-semibold">consumerKey:</span> {siaTokenData.consumerKey}
+                          </p>
+                        ) : null}
+                        {siaTokenData.dz ? (
+                          <p>
+                            <span className="font-semibold">dz:</span> {siaTokenData.dz}
+                          </p>
+                        ) : null}
+                        {siaTokenData[".issued"] ? (
+                          <p>
+                            <span className="font-semibold">.issued:</span> {siaTokenData[".issued"]}
+                          </p>
+                        ) : null}
+                        {siaTokenData[".expires"] ? (
+                          <p>
+                            <span className="font-semibold">.expires:</span> {siaTokenData[".expires"]}
+                          </p>
+                        ) : null}
                       </div>
                     ) : null}
                   </div>

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -132,8 +132,14 @@ export type BienestarSubmissionResponse = PqrsSubmissionResponse;
 export type BienestarPublicKeyResponse = PqrsPublicKeyResponse;
 
 export interface SiaTokenResponse {
-  sia_token: string;
-  sia_dz: string;
-  sia_consumer_key: string;
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  uid?: string;
+  ulogin?: string;
+  consumerKey?: string;
+  dz?: string;
+  ".issued"?: string;
+  ".expires"?: string;
 }
 


### PR DESCRIPTION
## Summary
- normalize the SIA token service to parse the new `access_token` response payload
- update the shared SiaTokenResponse type definition to match the latest API fields
- refresh the Bienestar page guard and token display to use the new response keys

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e41a1927b48330afa637eecf5ddb84