### PR TITLE
Add Node version endpoint and button on home page

### DIFF
--- a/client/pages/Home.tsx
+++ b/client/pages/Home.tsx
@@ -1,9 +1,36 @@
-import React from "react";
-
-import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 
+import { builderPublicKey, encodedBuilderPublicKey } from "@/lib/builder";
+import type { NodeVersionResponse } from "@shared/api";
+
 export default function Home() {
+  const [nodeVersion, setNodeVersion] = useState<NodeVersionResponse | null>(null);
+  const [isFetchingNodeVersion, setIsFetchingNodeVersion] = useState(false);
+  const [nodeVersionError, setNodeVersionError] = useState<string | null>(null);
+
+  const handleShowNodeVersion = async () => {
+    setIsFetchingNodeVersion(true);
+    setNodeVersionError(null);
+
+    try {
+      const response = await fetch("/api/node-version");
+
+      if (!response.ok) {
+        throw new Error("No se pudo obtener la versión de Node");
+      }
+
+      const data: NodeVersionResponse = await response.json();
+      setNodeVersion(data);
+    } catch (error) {
+      console.error("Error fetching Node version", error);
+      setNodeVersion(null);
+      setNodeVersionError("No se pudo obtener la versión de Node. Intenta de nuevo más tarde.");
+    } finally {
+      setIsFetchingNodeVersion(false);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-[#F0F0F0]">
       {/* Hero Banner */}
@@ -46,6 +73,36 @@ export default function Home() {
               asistencias que tenemos diseñadas para ti.
             </p>
           </div>
+        </div>
+      </section>
+
+      <section className="px-4 md:px-8 lg:px-[142px] py-6">
+        <div className="max-w-3xl mx-auto bg-white rounded-[12px] shadow-sm p-6 text-center">
+          <h2 className="text-[#0E0E0E] font-['Publico_Text_Web'] text-[24px] leading-[32px] mb-4">
+            Versión de Node del sitio
+          </h2>
+          <p className="text-[#0E0E0E] font-['Source_Sans_Pro'] text-[16px] leading-[24px] mb-6">
+            Consulta la versión de Node con la que se compiló y se está ejecutando la plataforma.
+          </p>
+          <button
+            type="button"
+            onClick={handleShowNodeVersion}
+            className="inline-flex items-center justify-center rounded-full bg-[#0C0E45] px-6 py-3 text-white font-['Source_Sans_Pro'] text-sm font-semibold tracking-[1.25px] uppercase transition hover:bg-[#0a0c3a] disabled:cursor-not-allowed disabled:opacity-70"
+            disabled={isFetchingNodeVersion}
+          >
+            {isFetchingNodeVersion ? "Consultando versión..." : "Mostrar versión de Node"}
+          </button>
+          {nodeVersion && (
+            <p className="mt-4 text-[#0E0E0E] font-['Source_Sans_Pro'] text-[16px] leading-[24px]">
+              Compilado con Node <span className="font-semibold">{nodeVersion.build}</span> y ejecutado con Node
+              <span className="font-semibold"> {nodeVersion.runtime}</span>.
+            </p>
+          )}
+          {nodeVersionError && (
+            <p className="mt-4 text-[#FF1721] font-['Source_Sans_Pro'] text-[14px] leading-[22px]">
+              {nodeVersionError}
+            </p>
+          )}
         </div>
       </section>
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { handleGetFormacionPublicKey, handleSubmitFormacion } from "./routes/for
 import { handleGetBienestarPublicKey, handleSubmitBienestar } from "./routes/bienestar";
 import { handleRequestSiaToken } from "./routes/sia";
 import { requireAuth } from "./middleware/require-auth";
+import { handleNodeVersion } from "./routes/node-version";
 
 export function createServer() {
   const app = express();
@@ -47,6 +48,7 @@ export function createServer() {
   app.get("/env", handleEnvironmentVariables);
   app.get("/api/demo", requireAuth, handleDemo);
   app.post("/api/email/send", requireAuth, handleSendEmail);
+  app.get("/api/node-version", handleNodeVersion);
   app.get("/api/pqrs/public-key", handleGetPqrsPublicKey);
   app.post("/api/pqrs", handleSubmitPqrs);
   app.get("/api/formacion/public-key", handleGetFormacionPublicKey);

--- a/server/routes/node-version.ts
+++ b/server/routes/node-version.ts
@@ -1,0 +1,13 @@
+import { RequestHandler } from "express";
+import { NodeVersionResponse } from "@shared/api";
+
+const buildNodeVersion = process.env.BUILD_NODE_VERSION ?? process.version;
+
+export const handleNodeVersion: RequestHandler = (_req, res) => {
+  const response: NodeVersionResponse = {
+    build: buildNodeVersion,
+    runtime: process.version,
+  };
+
+  res.json(response);
+};

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -143,3 +143,8 @@ export interface SiaTokenResponse {
   ".expires"?: string;
 }
 
+export interface NodeVersionResponse {
+  build: string;
+  runtime: string;
+}
+


### PR DESCRIPTION
## Summary
- add an API route that exposes the build and runtime Node versions
- surface a button on the home page that fetches and displays the versions

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e4396cbd588330a83f1dc302db5ec0