### PR TITLE
Add SIA FileAdd service helper

### DIFF
--- a/shared/api.ts
+++ b/shared/api.ts
@@ -165,6 +165,28 @@ export type SiaFileGetResponseItem = {
 
 export type SiaFileGetResponse = SiaFileGetResponseItem[];
 
+export interface SiaFileAddRequestBody {
+  sia_token: string;
+  sia_dz: string;
+  sia_consumer_key: string;
+  user_identification: string;
+  form_datetime: string;
+  form_code_service: string;
+  user_name: string;
+  user_last_name: string;
+  user_email: string;
+  user_mobile: string;
+  form_date: string;
+  form_hora: string;
+}
+
+export interface SiaFileAddResponse {
+  Success: boolean;
+  Code: string;
+  Message: string;
+  File: string;
+}
+
 export interface NodeVersionResponse {
   build: string;
   runtime: string;


### PR DESCRIPTION
## Summary
- add shared request/response types for invoking the SIA FileAdd endpoint
- implement the FileAdd helper in the server service to call CMServices with the required payload

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e47153d84083309adbc94f5425a98f