### PR TITLE
Add SIA FileAdd support to UI and backend

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ import { handleEnvironmentVariables } from "./routes/environment";
 import { handleGetPqrsPublicKey, handleSubmitPqrs } from "./routes/pqrs";
 import { handleGetFormacionPublicKey, handleSubmitFormacion } from "./routes/formacion";
 import { handleGetBienestarPublicKey, handleSubmitBienestar } from "./routes/bienestar";
-import { handleRequestSiaToken, handleSiaFileGet } from "./routes/sia";
+import { handleRequestSiaToken, handleSiaFileAdd, handleSiaFileGet } from "./routes/sia";
 import { requireAuth } from "./middleware/require-auth";
 import { handleNodeVersion } from "./routes/node-version";
 
@@ -57,6 +57,7 @@ export function createServer() {
   app.post("/api/bienestar", handleSubmitBienestar);
   app.post("/api/sia/token", handleRequestSiaToken);
   app.post("/api/sia/file-get", handleSiaFileGet);
+  app.post("/api/sia/file-add", handleSiaFileAdd);
   app.post("/api/auth/register", handleAuthRegister);
   app.post("/api/auth/login", handleAuthLogin);
   return app;

--- a/server/routes/sia.ts
+++ b/server/routes/sia.ts
@@ -1,11 +1,13 @@
 import type { RequestHandler } from "express";
 
 import type {
+  SiaFileAddRequestBody,
+  SiaFileAddResponse,
   SiaFileGetRequestBody,
   SiaFileGetResponse,
   SiaTokenResponse,
 } from "@shared/api";
-import { FileGet, requestSiaToken, SiaServiceError } from "../services/sia";
+import { FileAdd, FileGet, requestSiaToken, SiaServiceError } from "../services/sia";
 
 const sanitizeSiaFileGetBody = (body: unknown): SiaFileGetRequestBody => {
   if (typeof body !== "object" || body === null) {
@@ -20,6 +22,40 @@ const sanitizeSiaFileGetBody = (body: unknown): SiaFileGetRequestBody => {
   ];
 
   const parsed = Object.create(null) as SiaFileGetRequestBody;
+
+  for (const field of requiredFields) {
+    const value = (body as Record<string, unknown>)[field];
+    if (typeof value !== "string" || !value.trim()) {
+      throw new SiaServiceError(`El campo "${field}" es obligatorio.`, 400);
+    }
+
+    parsed[field] = value.trim();
+  }
+
+  return parsed;
+};
+
+const sanitizeSiaFileAddBody = (body: unknown): SiaFileAddRequestBody => {
+  if (typeof body !== "object" || body === null) {
+    throw new SiaServiceError("El cuerpo de la solicitud es inválido.", 400);
+  }
+
+  const requiredFields: (keyof SiaFileAddRequestBody)[] = [
+    "sia_token",
+    "sia_dz",
+    "sia_consumer_key",
+    "user_identification",
+    "form_datetime",
+    "form_code_service",
+    "user_name",
+    "user_last_name",
+    "user_email",
+    "user_mobile",
+    "form_date",
+    "form_hora",
+  ];
+
+  const parsed = Object.create(null) as SiaFileAddRequestBody;
 
   for (const field of requiredFields) {
     const value = (body as Record<string, unknown>)[field];
@@ -77,6 +113,36 @@ export const handleSiaFileGet: RequestHandler = async (req, res) => {
 
     console.error("Unexpected error calling SIA FileGet", error);
     res.status(500).json({ error: "Ocurrió un error al consultar FileGet de SIA." });
+  }
+};
+
+export const handleSiaFileAdd: RequestHandler = async (req, res) => {
+  let body: SiaFileAddRequestBody;
+
+  try {
+    body = sanitizeSiaFileAddBody(req.body);
+  } catch (error) {
+    if (error instanceof SiaServiceError && error.status === 400) {
+      return res.status(error.status).json({ error: error.message });
+    }
+
+    console.error("Invalid SIA FileAdd request body", error);
+    return res.status(400).json({ error: "El cuerpo de la solicitud es inválido." });
+  }
+
+  try {
+    const response: SiaFileAddResponse = await FileAdd(body);
+    res.json(response);
+  } catch (error) {
+    if (error instanceof SiaServiceError) {
+      if (error.status >= 500) {
+        console.error("SIA FileAdd service error", error);
+      }
+      return res.status(error.status).json({ error: error.message, details: error.details });
+    }
+
+    console.error("Unexpected error calling SIA FileAdd", error);
+    res.status(500).json({ error: "Ocurrió un error al invocar FileAdd de SIA." });
   }
 };
 


### PR DESCRIPTION
## Summary
- add a FileAdd form to the SIA page so users can submit all required parameters and review the response
- expose a `/api/sia/file-add` endpoint that validates the payload and calls the SIA service
- register the new FileAdd route in the server

## Testing
- pnpm test *(fails: GET /api/demo > returns a public demo payload with permissive CORS headers — expected 200, received 401)*

------
https://chatgpt.com/codex/tasks/task_e_68e47667d9d08330a5f136df2587ba2d